### PR TITLE
Add GPU access and make Flash data dirs writable

### DIFF
--- a/com.adobe.Flash-Player-Projector.json
+++ b/com.adobe.Flash-Player-Projector.json
@@ -8,9 +8,13 @@
     "finish-args" : [
         /* X11 + XShm access */
         "--share=ipc", "--socket=x11",
+        /* GPU acceleration */
+        "--device=dri",
         /* Play sounds */
         "--socket=pulseaudio",
         /* Get access to the files */
+        "--filesystem=~/.adobe:create",
+        "--filesystem=~/.macromedia:create",
         "--filesystem=host:ro",
         "--filesystem=xdg-run/gvfs:ro"
     ],


### PR DESCRIPTION
GPU access is needed for e.g. some 3D games or hw-accelerated video decode.
Flash stores some data on disk, so that directories should be writable.