### PR TITLE
appdata: Remove link from description

### DIFF
--- a/com.adobe.Flash-Player-Projector.appdata.xml
+++ b/com.adobe.Flash-Player-Projector.appdata.xml
@@ -14,8 +14,8 @@
       The Adobe Flash Player Projector is an offline player for content created on the Adobe Flash platform.
     </p>
     <p>
-      While the Flash platform is abandoned, there's still <a href="https://archive.org/details/softwarelibrary_flash">a lot of vintage
-      content available for download</a>, such as games, and animations from Flash's “Golden Age”.
+      While the Flash platform is abandoned, there's still a lot of vintage
+      content available for download, such as games, and animations from Flash's “Golden Age”.
     </p>
     <p>NOTE: This wrapper is not verified by, affiliated with, or supported by Adobe, and does not contain a web browser plug-in.</p>
   </description>

--- a/com.adobe.Flash-Player-Projector.appdata.xml
+++ b/com.adobe.Flash-Player-Projector.appdata.xml
@@ -20,6 +20,7 @@
     <p>NOTE: This wrapper is not verified by, affiliated with, or supported by Adobe, and does not contain a web browser plug-in.</p>
   </description>
   <url type="homepage">https://www.adobe.com/support/flashplayer/debug_downloads.html</url>
+  <url type="help">https://archive.org/details/softwarelibrary_flash</url>
   <screenshots>
     <screenshot type="default">
       <caption>Playing “Samorost 2”</caption>


### PR DESCRIPTION
The AppStream spec says:

> Some markup can be used.
> Do not assume the format is HTML.

<a> is not one of the supported markup elements documented in the spec, and both Flathub.org and GNOME Software just omit the entire tag from the description, leaving it broken.

![Screenshot from 2023-08-02 20-27-02](https://github.com/flathub/com.adobe.Flash-Player-Projector/assets/86760/3d9933cb-12a9-464f-9458-800c6e56ce08)
![Screenshot from 2023-08-02 20-26-55](https://github.com/flathub/com.adobe.Flash-Player-Projector/assets/86760/b98ed2b0-071c-4919-a47e-4b73ade89686)

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-description